### PR TITLE
Moving Eleventy require into config to avoid circular dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-const Eleventy = require("@11ty/eleventy");
 const shimmer = require("shimmer");
 const processor = require("./src/processor");
 
@@ -6,7 +5,7 @@ module.exports = {
     initArguments: {},
     configFunction: (__, options = {}) => {
         setImmediate(function () {
-
+            const Eleventy = require("@11ty/eleventy");
             shimmer.wrap(Eleventy.prototype, "write", function (original) {
                 return function () {
                     if (!this.isDryRun) {


### PR DESCRIPTION
I was trying to implement this module into a personal project, a rather small fresh 11ty site, and Node 14 was reporting circular dependencies.

I investigated a couple of other modules (like [this file in the Sass plugin](https://github.com/Sonaryr/eleventy-plugin-sass/blob/master/index.js)) and it seems like this is a pattern to avoid that circular dependency

In the sample project in the repo, I couldn't reproduce the circular dep, but when both eleventy and this plugin are in `node_modules`, it seems like it creates one.

In theory, should maybe check to make sure that `Eleventy.prototype` exists and isn't undefined, happy to put that in place if desired.