### PR TITLE
Use path.posix.join to prevent bug on windows

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -10,7 +10,7 @@ module.exports = async function (options, isWatch) {
     const inputDir = elev.inputDir;
     const outputDir = elev.outputDir;
     const defaultOptions = {
-        src: path.join(inputDir, "**/*.css"),
+        src: path.posix.join(inputDir, "**/*.css"),
         dest: ".",
         configFile: "tailwind.config.js",
         watchEleventyWatchTargets: false,


### PR DESCRIPTION
fastglob only takes unix style paths. This causes it to fail to find any files on windows machines.