### PR TITLE
Fix the glob pattern of excludeNonCssFiles

### DIFF
--- a/src/processor.js
+++ b/src/processor.js
@@ -47,7 +47,7 @@ module.exports = async function(userOptions, isWatch) {
     ignore: [
       options.dest,
       ...options.excludeNodeModules ? ['node_modules/**/*'] : [],
-      ...options.excludeNonCssFiles ? ['**/*.!(css)'] : []
+      ...options.excludeNonCssFiles ? ['!(**.css)'] : []
     ]
   });
 

--- a/src/processor.js
+++ b/src/processor.js
@@ -47,7 +47,7 @@ module.exports = async function(userOptions, isWatch) {
     ignore: [
       options.dest,
       ...options.excludeNodeModules ? ['node_modules/**/*'] : [],
-      ...options.excludeNonCssFiles ? ['**/!(*.css)'] : []
+      ...options.excludeNonCssFiles ? ['**/*.!(css)'] : []
     ]
   });
 


### PR DESCRIPTION
```js
~/Coding/vredeburg/src/assets/css
❯ tree
.
├── custom-forms.css
├── main.css
├── nouislider.min.css
├── something.txt
└── testdir
    └── nested.css

1 directory, 5 files

~/Coding/vredeburg/src/assets/css
❯ node
Welcome to Node.js v16.6.1.
Type ".help" for more information.
> const fg = require("fast-glob")
undefined
> await fg("**", {"ignore": ['**/!(*.css)']})
[]
> await fg("**", {"ignore": ['!(**.css)']})
[
  'custom-forms.css',
  'main.css',
  'nouislider.min.css',
  'testdir/nested.css'
]
> 
```
As you can see, using `'**/!(*.css)'` excludes everything from the results.